### PR TITLE
Handle nils when serializing rails yaml

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,6 @@
+== 3.0.1
+* Handle nil values in Rails YAML serializer (convert them to empty strings).
+
 == 3.0.0
 
 * Upgrade to yaml-write-stream v2, which dumps YAML scalars more consistently.

--- a/lib/abroad/serializers/yaml/rails_serializer.rb
+++ b/lib/abroad/serializers/yaml/rails_serializer.rb
@@ -16,7 +16,7 @@ module Abroad
 
         def write_key_value(key, value)
           key_parts = split_key(key)
-          encoded_value = value.encode(encoding)
+          encoded_value = value.encode(encoding) if value
           trie.add(key_parts, encoded_value)
         end
 
@@ -57,7 +57,7 @@ module Abroad
         end
 
         def write_value(node, parent_key)
-          value = node ? node.value : ''
+          value = (node ? node.value : '') || ''
           if writer.in_map?
             writer.write_key_value(parent_key, value)
           else

--- a/lib/abroad/version.rb
+++ b/lib/abroad/version.rb
@@ -1,3 +1,3 @@
 module Abroad
-  VERSION = '3.0.0'
+  VERSION = '3.0.1'
 end

--- a/spec/serializers/yaml/rails_serializer_spec.rb
+++ b/spec/serializers/yaml/rails_serializer_spec.rb
@@ -168,4 +168,12 @@ describe Yaml::RailsSerializer do
       }
     })
   end
+
+  it 'converts nils to empty strings' do
+    result = serialize do
+      serializer.write_key_value('foo.bar', nil)
+    end
+
+    expect(result).to eq('fr' => { 'foo' => { 'bar' => '' } })
+  end
 end


### PR DESCRIPTION
Currently, this breaks the Rails YAML serializer:

```ruby
serializer.write_key_value('foo.bar', nil)
```