### PR TITLE
Add txt support

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,6 @@
+== 4.2.0
+* Add support for text files.
+
 == 4.1.3
 * Leave nils alone.
 

--- a/lib/abroad.rb
+++ b/lib/abroad.rb
@@ -8,10 +8,12 @@ module Abroad
   Extractors.register('yaml/dotted-key', Extractors::Yaml::DottedKeyExtractor)
   Extractors.register('json/key-value', Extractors::Json::KeyValueExtractor)
   Extractors.register('xml/android', Extractors::Xml::AndroidExtractor)
+  Extractors.register('txt/lines', Extractors::Txt::LinesExtractor)
 
   Serializers.register('yaml/rails', Serializers::Yaml::RailsSerializer)
   Serializers.register('json/key-value', Serializers::Json::KeyValueSerializer)
   Serializers.register('xml/android', Serializers::Xml::AndroidSerializer)
+  Serializers.register('txt/lines', Serializers::Txt::LinesSerializer)
 
   class << self
     def extractors

--- a/lib/abroad/extractors.rb
+++ b/lib/abroad/extractors.rb
@@ -2,6 +2,7 @@ module Abroad
   module Extractors
     autoload :Extractor, 'abroad/extractors/extractor'
     autoload :Json,      'abroad/extractors/json'
+    autoload :Txt,       'abroad/extractors/txt'
     autoload :Xml,       'abroad/extractors/xml'
     autoload :Yaml,      'abroad/extractors/yaml'
 

--- a/lib/abroad/extractors/txt.rb
+++ b/lib/abroad/extractors/txt.rb
@@ -1,0 +1,8 @@
+module Abroad
+  module Extractors
+    module Txt
+      autoload :LinesExtractor, 'abroad/extractors/txt/lines_extractor'
+      autoload :TxtExtractor,   'abroad/extractors/txt/txt_extractor'
+    end
+  end
+end

--- a/lib/abroad/extractors/txt/lines_extractor.rb
+++ b/lib/abroad/extractors/txt/lines_extractor.rb
@@ -1,0 +1,22 @@
+require 'json/stream'
+
+module Abroad
+  module Extractors
+    module Txt
+
+      class LinesExtractor < TxtExtractor
+        private
+
+        def each_entry
+          return to_enum(__method__) unless block_given?
+
+          stream.read.split(/\r?\n/).each_with_index do |line, idx|
+            # keys should always be strings
+            yield idx.to_s, line
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/abroad/extractors/txt/lines_extractor.rb
+++ b/lib/abroad/extractors/txt/lines_extractor.rb
@@ -10,9 +10,9 @@ module Abroad
         def each_entry
           return to_enum(__method__) unless block_given?
 
-          stream.read.split(/\r?\n/).each_with_index do |line, idx|
+          stream.each_line.with_index do |line, idx|
             # keys should always be strings
-            yield idx.to_s, line
+            yield idx.to_s, line.chomp
           end
         end
       end

--- a/lib/abroad/extractors/txt/txt_extractor.rb
+++ b/lib/abroad/extractors/txt/txt_extractor.rb
@@ -1,0 +1,17 @@
+module Abroad
+  module Extractors
+    module Txt
+
+      class TxtExtractor < Extractor
+        def extract_each(options = {}, &block)
+          if block_given?
+            each_entry(&block)
+          else
+            to_enum(__method__, options)
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/abroad/serializers.rb
+++ b/lib/abroad/serializers.rb
@@ -2,6 +2,7 @@ module Abroad
   module Serializers
     autoload :Json,       'abroad/serializers/json'
     autoload :Serializer, 'abroad/serializers/serializer'
+    autoload :Txt,        'abroad/serializers/txt'
     autoload :Trie,       'abroad/serializers/trie'
     autoload :Xml,        'abroad/serializers/xml'
     autoload :Yaml,       'abroad/serializers/yaml'

--- a/lib/abroad/serializers/txt.rb
+++ b/lib/abroad/serializers/txt.rb
@@ -1,0 +1,8 @@
+module Abroad
+  module Serializers
+    module Txt
+      autoload :TxtSerializer,   'abroad/serializers/txt/txt_serializer'
+      autoload :LinesSerializer, 'abroad/serializers/txt/lines_serializer'
+    end
+  end
+end

--- a/lib/abroad/serializers/txt/lines_serializer.rb
+++ b/lib/abroad/serializers/txt/lines_serializer.rb
@@ -1,0 +1,52 @@
+module Abroad
+  module Serializers
+    module Txt
+
+      class LinesSerializer < TxtSerializer
+        DEFAULT_NEWLINE_SEPARATOR = "\n"
+
+        attr_reader :newline_separator, :lines
+
+        def initialize(stream, locale, options = {})
+          @newline_separator = options.fetch(:newline_separator, DEFAULT_NEWLINE_SEPARATOR)
+          @lines = []
+          super
+        end
+
+        def write_key_value(key, value)
+          unless valid_key?(key)
+            raise KeyError, "'#{key}' is not a valid key"
+          end
+
+          add_line(key, value)
+        end
+
+        def flush
+          stream.write(lines.join(newline_separator))
+          super
+        end
+
+        private
+
+        def add_line(key, value)
+          key = parse_key(key)
+
+          if key >= lines.size
+            lines.concat(Array.new(key - lines.size + 1) { '' })
+          end
+
+          lines[key] = value
+        end
+
+        def parse_key(key)
+          key.to_i
+        end
+
+        def valid_key?(key)
+          !!(key =~ /[\d]+/)
+        end
+      end
+
+    end
+  end
+end

--- a/lib/abroad/serializers/txt/txt_serializer.rb
+++ b/lib/abroad/serializers/txt/txt_serializer.rb
@@ -1,0 +1,15 @@
+require 'stringio'
+
+module Abroad
+  module Serializers
+    module Txt
+
+      class TxtSerializer < Serializer
+        def write_raw(text)
+          stream.write(text)
+        end
+      end
+
+    end
+  end
+end

--- a/lib/abroad/version.rb
+++ b/lib/abroad/version.rb
@@ -1,3 +1,3 @@
 module Abroad
-  VERSION = '4.1.3'
+  VERSION = '4.2.0'
 end

--- a/spec/extractors/txt/lines_extractor_spec.rb
+++ b/spec/extractors/txt/lines_extractor_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+include Abroad::Extractors
+
+describe Txt::LinesExtractor do
+  it 'extracts text into lines' do
+    text = outdent(%Q(
+      foo
+
+      bar
+
+      baz
+      boo
+    ))
+
+    strings = described_class.from_string(text).extract_each.to_a
+
+    expect(strings).to eq([
+      ['0', 'foo'], ['1', ''],    ['2', 'bar'],
+      ['3', ''],    ['4', 'baz'], ['5', 'boo']
+    ])
+  end
+end

--- a/spec/serializers/txt/lines_serializer_spec.rb
+++ b/spec/serializers/txt/lines_serializer_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+include Abroad::Serializers
+
+describe Txt::LinesSerializer do
+  let(:stream) { StringIO.new }
+  let(:locale) { 'en' }
+  let(:serializer) { described_class.from_stream(stream, locale) }
+
+  it 'writes key/value pairs' do
+    serializer.write_key_value('2', 'foo')
+    serializer.write_key_value('3', 'bar')
+    serializer.write_key_value('5', 'baz')
+
+    serializer.close
+    expect(stream.string).to eq(outdent(%Q(
+
+
+      foo
+      bar
+
+      baz
+    )).rstrip)
+  end
+
+  it 'raises an error if given a non-numeric key' do
+    expect { serializer.write_key_value('abc', 'def') }.to(
+      raise_error(KeyError)
+    )
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,10 +4,19 @@ require 'rspec'
 require 'abroad'
 require 'yaml'
 
-RSpec.configure do |config|
-  def camelize(str)
-    str.gsub(/(^\w|[-_]\w)/) { $1[-1].upcase }
+module SpecHelpers
+  def outdent(str)
+    # The special YAML pipe operator treats the text that follows as literal,
+    # and includes newlines, tabs, and spaces. It also strips leading tabs and
+    # spaces. This means you can include a fully indented bit of, say, source
+    # code in your source code, and it will give you back a string with all the
+    # indentation preserved (but without any leading indentation).
+    YAML.load("|#{str}")
   end
+end
+
+RSpec.configure do |config|
+  config.include(SpecHelpers)
 
   shared_examples 'a fixture-based extractor' do |dir, namespace|
     fixture_manifest = YAML.load_file(File.join(dir, 'fixtures.yml'))


### PR DESCRIPTION
Text files have no inherent structure, so they can be handled in a number of ways (entire file, by sentence, by line, by paragraph, etc). Our use case needs extraction and serialization by line.